### PR TITLE
Fix failing importer unit test

### DIFF
--- a/importers/src/stepdata/step-lexicon/tests/importer.test.ts
+++ b/importers/src/stepdata/step-lexicon/tests/importer.test.ts
@@ -93,15 +93,6 @@ describe('parseStrongsDefinitions', () => {
             },
             {
                 strong: 'G0004',
-                dictionary: '@FLsjDefs',
-                lemma: 'ἀβαρής',
-                transliteration: 'abarḗs',
-                gloss: 'not burdensome',
-                content:
-                    '<b> ἀβαρής</b>, ές, <br /> (βάρος) <b>without weight,</b> [<a href="javascript:void(0)" title=" 4th c.BC: Aristoteles Philosophus “de Caelo” 277b19; ἀβαρῆ εἶναι ἀέρα καὶ πῦρ 4th-3rd c.BC: Zeno Citieus Stoicus 1.27, compare 3rd c.BC: Chrysippus Stoicus 2.143, 3rd c.AD: Plotinus Philosophus 6.9.9, etc.">Refs 4th c.BC+</a>]; <b>light,</b> γῆ[<a href="javascript:void(0)" title=" “Anthologia Graeca” 7.461 (1st c.BC: Meleager Epigrammaticus): _metaphorically_, ἀ. χρῆμα">Refs 1st c.BC+</a>] a <b>light</b> matter, [<a href="javascript:void(0)" title=" “Comica Adespota” 158; παρρησία.. μαλακὴ καὶ ἀ. 1st-2nd c.AD: Plutarchus Biographus et Philosophus 2.59c ">Refs 1st c.AD+</a>]; of the pulse, [<a href="javascript:void(0)" title=" 2nd c.AD: Archigenes Medicus cited in 2nd c.AD: Galenus Medicus 8.651. ">Refs 2nd c.AD+</a>]<br /><Level2><b>__II</b></Level2> <b>not offensive,</b> ὀσμαί[<a href="javascript:void(0)" title=" 2nd c.AD: Aretaeus Medicus “ὀξέων νούσων θεραπευτικόν” 2.3 ">Refs 2nd c.AD+</a>]; of persons, <b>not burdensome,</b> ἀ. ἑαυτὸν τηρεῖν, παρέχειν, [<a href="javascript:void(0)" title=" NT.2Cor.11.9, “CIG” “Corpus Inscriptionum Graecarum” “Corpus Inscriptionum Graecarum” 5361.15 (from Berenice)">NT</a>]. <i>adverb</i> <b>-ρῶς</b> <b>without giving offence,</b> [<a href="javascript:void(0)" title=" 6th c.AD: Simplicius Philosophus “in Epictetum commentaria” p.85D.">Refs 6th c.AD+</a>]; <b>without taking offence,</b> [<a href="javascript:void(0)" title="[prev. work] p.88D.">Refs</a>]',
-            },
-            {
-                strong: 'G0004',
                 dictionary: '@es_Definition',
                 lemma: 'ἀβαρής',
                 transliteration: 'abarḗs',


### PR DESCRIPTION
## Why It Failed

Initially, I wanted to include the full LSJ in the mobile app; however, it ended up being too large and unwieldy, so I dropped support for this.

I removed LSJ parsing from the importer, but neglected to update the unit test; this oversight has caused the overall suite to appear failing on master for many months.